### PR TITLE
fix: call getter accumulator with proper `this` context

### DIFF
--- a/bin/test.ts
+++ b/bin/test.ts
@@ -3,7 +3,7 @@ import { expectTypeOf } from '@japa/expect-type'
 import { specReporter } from '@japa/spec-reporter'
 import { runFailedTests } from '@japa/run-failed-tests'
 import { processCliArgs, configure, run } from '@japa/runner'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { pathToFileURL } from 'node:url'
 
 /*
 |--------------------------------------------------------------------------

--- a/bin/test.ts
+++ b/bin/test.ts
@@ -3,6 +3,7 @@ import { expectTypeOf } from '@japa/expect-type'
 import { specReporter } from '@japa/spec-reporter'
 import { runFailedTests } from '@japa/run-failed-tests'
 import { processCliArgs, configure, run } from '@japa/runner'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 /*
 |--------------------------------------------------------------------------
@@ -23,7 +24,7 @@ configure({
     files: ['tests/**/*.spec.ts'],
     plugins: [assert(), runFailedTests(), expectTypeOf()],
     reporters: [specReporter()],
-    importer: (filePath) => import(filePath),
+    importer: (filePath) => import(pathToFileURL(filePath).href),
   },
 })
 

--- a/index.ts
+++ b/index.ts
@@ -56,7 +56,7 @@ export default abstract class Macroable {
   ): void {
     Object.defineProperty(this.prototype, name, {
       get() {
-        const value = accumulator()
+        const value = accumulator.call(this)
 
         if (singleton) {
           Object.defineProperty(this, name, {

--- a/tests/macroable.spec.ts
+++ b/tests/macroable.spec.ts
@@ -101,4 +101,18 @@ test.group('Macroable | getter', () => {
     assert.isTrue(Object.hasOwn(parent, 'getCount'))
     assert.equal(counter, 1)
   })
+
+  test('getter function should be called with parent this context', ({ assert, expectTypeOf }) => {
+    class Parent extends Macroable {
+      declare getter: any
+    }
+
+    Parent.getter('getter', function getter(this: Parent) {
+      expectTypeOf(this).toEqualTypeOf<Parent>()
+      return this
+    })
+
+    const parent = new Parent()
+    assert.equal(parent.getter, parent)
+  })
 })


### PR DESCRIPTION
## Proposed changes

Without this fix, then the following code did not work: 

```ts
class Foo extends Macroable {
  public value = "foo";
}

Foo.getter("bar", function (this: Foo) {
  console.log(this); // print undefined
  return this.value;
});

const foo = new Foo();
console.log(foo.bar);
```

In other words: the `this` context was not passed to the getters callback. I added a test in the PR that showed this behavior.
This also caused an undesired breaking change