### PR TITLE
Fix configurable property value in README.md to match implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Object.defineProperty(Route.prototype, 'version', {
     const value = callback()
     return value
   },
-  configurable: false,
+  configurable: true,
   enumerable: false,
 })
 ```
@@ -127,7 +127,7 @@ Object.defineProperty(Mysql.prototype, 'version', {
 
     return value
   },
-  configurable: false,
+  configurable: true,
   enumerable: false,
 })
 ```


### PR DESCRIPTION
This is a minor documentation correction to the package, as the readme's "how this is implemented" did not actually line up with how things were implemented.